### PR TITLE
Fix link to CSharp introduction in index.js

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ const languages = [
   {
     title: 'C#',
     imageUrl: 'images/CSharpLogo.svg',
-    docsLink: 'docs/stryker-net/introduction',
+    docsLink: 'docs/stryker-net/Introduction',
   },
   {
     title: 'Scala',


### PR DESCRIPTION
The link from the logo on the front page went to Page not found